### PR TITLE
Bug: Monty is not able to pick the door I chose

### DIFF
--- a/monty-hall.rb
+++ b/monty-hall.rb
@@ -1,5 +1,5 @@
 DOORS = [:door1, :door2, :door3]
-TESTS = 1000000
+TESTS = 10000
 
 stick_wins = 0
 switch_wins = 0
@@ -30,27 +30,30 @@ end
   prize_door = doors.shuffle.first
   # Randomise the chosen door from all doors
   chosen_door = doors.shuffle.first
+  
   # Make a list of empty doors
   doors.delete(prize_door)
-  empty_doors = doors.dup
+  doors.delete(chosen_door)
+  doors_available_for_monty = doors.dup
+
   # Monty picks a random door from the list of empty doors
-  monty_door = empty_doors.shuffle.first
-  empty_doors.delete(monty_door)
+  monty_door = doors_available_for_monty.shuffle.first
+
   # empty_doors is now a one-item array containing the door
   # that has not been either chosen or opened by Monty.
   # Figure out which door we get if we switch doors
   doors = DOORS.dup
   doors.delete(monty_door)
   doors.delete(chosen_door)
-  chosen_door = doors.first
-  if (prize_door == chosen_door)
+
+  new_chosen_door = doors.first
+  if (prize_door == new_chosen_door)
     switch_wins += 1
   end
 end
 
 # Work out the results
-# With 1,000,000 tests, this is almost always 33% wins for
-# sticking, and 50% wins for switching, which fits exactly
-# with the maths.  Fewer tests will yield less accurate results.
+# With 1,000 tests, this is almost always 33% wins for
+# sticking, and 66% wins for switching as proved mathematically in https://en.wikipedia.org/wiki/Monty_Hall_problem
 puts "Sticking won " + ((stick_wins.to_f / TESTS.to_f) * 100).to_i.to_s + "%"
 puts "Switching won " + ((switch_wins.to_f / TESTS.to_f) * 100).to_i.to_s + "%"


### PR DESCRIPTION
The actual probability is 66% for switching, not 50%. The problem was that Monty was able to open my door in the code. Here it doesn't happen anymore and the probability is now correctly 66%